### PR TITLE
[PBW-3211][Chromecast] Doing Replay of cast asset gives, "brain freeze"

### DIFF
--- a/receiver_custom.html
+++ b/receiver_custom.html
@@ -283,9 +283,12 @@
               case OO.EVENTS.PLAYBACK_READY:
                 if (autoPlay) {
                   // Controlled extention of displaying loading screen, currently set to 3 seconds.  
+                  // ATTN: Receiver HAS TO publish CAN_PLAY in case of autoPlay
                   setTimeout(function() {
                     player.mb.publish(OO.EVENTS.CAN_PLAY);
                   }, 3000);
+                } else {
+                  player.mb.publish(OO.EVENTS.CAN_PLAY);
                 }
                 break;
               case OO.EVENTS.STREAM_PLAYING:


### PR DESCRIPTION
- Reworked showScreen, delaying of initial playback is done in playback control module
- Also, check for player object for seek and change volume - sender web page may cause exceptions (not related to this bug, but still good to have)
