### PR TITLE
[PBW-3193][Chromecast] Default Receiver is not disconnecting after 5 …

### DIFF
--- a/receiver_custom.html
+++ b/receiver_custom.html
@@ -834,7 +834,7 @@
       var pauseEvents = [ OO.EVENTS.PAUSED, OO.EVENTS.PLAY, OO.EVENTS.SEEK,
                           OO.EVENTS.CHANGE_VOLUME, OO.EVENTS.SET_EMBED_CODE ];
       var splashEvents = [ OO.EVENTS.PLAYED, OO.EVENTS.SET_EMBED_CODE ];
-      var loadingEvents = [ OO.EVENTS.SET_EMBED_CODE, OO.EVENTS.PLAY, OO.EVENTS.INITIAL_PLAY, OO.EVENTS.CAN_PLAY ];
+      var loadingEvents = [ OO.EVENTS.SET_EMBED_CODE, OO.EVENTS.PLAY];
 
       // timeoutmanager instance to handle timeouts related to timing out on the splash screen
       var splashTimeout = new _TimeoutManager(SPLASH_SCREEN_TIMEOUT_MILLIS, splashEvents, player,
@@ -856,8 +856,6 @@
       function(evt) {
         switch (evt) {
           // If started playing, clear timeout
-          case OO.EVENTS.INITIAL_PLAY:
-          case OO.EVENTS.CAN_PLAY:
           case OO.EVENTS.PLAY:
             this.stopTimeout();
             break;


### PR DESCRIPTION
…minutes timeout on splash screen

Removed redundant events that trigger stopping of timeout too early
