### PR TITLE
[PBW-3775][Chromecast] Live assets should display "live" on the receiver side

### DIFF
--- a/receiver_custom.html
+++ b/receiver_custom.html
@@ -957,7 +957,7 @@
 
       //labels using the equivalent of OO.formatSeconds
       this.playheadLabel.innerHTML = timeFormat(played || 0);
-      this.durationLabel.innerHTML = timeFormat(maxTime || 0);
+      this.durationLabel.innerHTML = isLiveStream ? "Live" : timeFormat(maxTime || 0);
     }
 
     /**


### PR DESCRIPTION
- Duration label now shows "Live" if it is live asset
