### PR TITLE
Fix for initialTime 

### DIFF
--- a/lib/src/app/player.js
+++ b/lib/src/app/player.js
@@ -93,6 +93,13 @@ class CastPlayer {
     if (typeof data.params === 'object') {
       Object.assign(params, data.params);
     }
+
+    // we need to remove the 'initialTime' param from the previous asset
+    // only if it was not set or is equal to zero.
+    if (!data.params.initialTime) {
+      delete params.initialTime;
+    }
+
     this.params = createPageLevelParameters(
       params,
       this.onCreateHandlers.bind(this)


### PR DESCRIPTION
This branch contains a fix for reset or delete the value for the player param `initialTime` on any attempt to play a different asset.

Right now if the sender tries to load an asset in the receiver while this is playing another one the new asset will start playing at the same position of the first played asset.  

