### PR TITLE
[PLAYER-4735] Duration not reflected on replay asset

### DIFF
--- a/lib/src/app/player.js
+++ b/lib/src/app/player.js
@@ -473,6 +473,12 @@ class CastPlayer {
       this.onApiError.bind(this)
     );
 
+    player.mb.subscribe(
+      OO.EVENTS.WILL_PLAY_FROM_BEGINNING,
+      PLAYER_NAMESPACE,
+      this.onPlaybackReady.bind(this)
+    )
+
     // check if onCreate was defined and it's a function
     if (this.onCreate !== undefined && typeof this.onCreate === 'function') {
       this.onCreate(player);


### PR DESCRIPTION
This branch contains a quick fix to report to the sender the asset duration once the user tries to replay the asset.