### PR TITLE
[PLAYER-4063][ChromeCast][Receiver] ControlBar is not displayed

### DIFF
--- a/lib/src/app/helpers/createPageLevelParameters.js
+++ b/lib/src/app/helpers/createPageLevelParameters.js
@@ -30,6 +30,9 @@ export function createPageLevelParameters (pageLevelParameters, onCreateHandlers
       // so we need to merge handlers together
       onCreate: onCreateHandlers,
     },
+    chromecast: {
+      isReceiver: true
+    }
   };
 
   return pageLevelParametersOverrides;


### PR DESCRIPTION
Jira issue [link](https://jira.corp.ooyala.com/browse/PLAYER-4063)

Clicking on the Pause/Play button and seeking forward/backward on the sender device does not show the current play head time and video duration on the receiver side.Also the control/Progress bar itself is not displayed at the receiver end.

Corresponding html5-skin update is [here](https://github.com/ooyala/html5-skin/pull/1165)