### PR TITLE
[PLAYER-5026][WEB][Chromecast] Reload the page when casting

### DIFF
--- a/lib/src/app/player.js
+++ b/lib/src/app/player.js
@@ -157,9 +157,11 @@ class CastPlayer {
 
       case 'getstatus':
         let status = {
+          action: 'statusUpdate',
           state: this.OOPlayer.getState(),
           playhead: this.playhead,
           embed: this.OOPlayer.getEmbedCode(),
+          isCompleted: this.isCompleted,
         };
         logger.info(LOG_PREFIX, 'MessageBus status:', status);
         this.mb.send(event.senderId, status);


### PR DESCRIPTION
[Jira Link](https://jira.corp.ooyala.com/browse/PLAYER-5026)

This issue manifests itself when playback is done and I want to reload the page (when casting)

Steps:
* Open the debug link: https://tinyurl.com/yc2my2c8
* Connect to chromecast
* Video plays on receiver
* Refresh the page when playback's ended
* Player shows the start screen with play button but on clicking the play button it buffers indefinitely

